### PR TITLE
Add Firebase PVN to catalog

### DIFF
--- a/data/services.yaml
+++ b/data/services.yaml
@@ -1510,5 +1510,4 @@ services:
     jwks_uri: https://sso.malwarebytes.com/realms/master/protocol/openid-connect/certs
   - id: firebase-pvn
     name: Firebase PVN
-    openid-configuration: https://fpnv.googleapis.com/.well-known/openid-configuration
     jwks_uri: https://fpnv.googleapis.com/v1beta/jwks

--- a/data/services.yaml
+++ b/data/services.yaml
@@ -1508,3 +1508,7 @@ services:
     name: Malwarebytes
     openid-configuration: https://sso.malwarebytes.com/realms/master/.well-known/openid-configuration
     jwks_uri: https://sso.malwarebytes.com/realms/master/protocol/openid-connect/certs
+  - id: firebase-pvn
+    name: Firebase PVN
+    openid-configuration: https://fpnv.googleapis.com/.well-known/openid-configuration
+    jwks_uri: https://fpnv.googleapis.com/v1beta/jwks


### PR DESCRIPTION
Add Firebase PVN (Firebase Project Verification Network) to the services catalog.

- **ID:** firebase-pvn
- **JWKS URI:** https://fpnv.googleapis.com/v1beta/jwks
