### PR TITLE
fix: move 'on GitHub' text outside jwks-observer footer link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
             <a href="https://github.com/UnitVectorY-Labs">UnitVectorY Labs</a> | 
             <a href="https://opensource.org/licenses/MIT">MIT License</a> | 
             <a href="https://github.com/UnitVectorY-Labs/jwks-catalog"><strong>jwks-catalog</strong></a> and
-            <a href="https://github.com/UnitVectorY-Labs/jwks-observer"><strong>jwks-observer</strong> on GitHub</a>
+            <a href="https://github.com/UnitVectorY-Labs/jwks-observer"><strong>jwks-observer</strong></a> on GitHub
         </p>
     </footer>
 


### PR DESCRIPTION
Move the 'on GitHub' text outside the `<a>` tag for the jwks-observer link in the footer, so it's not part of the clickable link.